### PR TITLE
Adjust grype task

### DIFF
--- a/examples/cosign/pipeline-ko.yaml
+++ b/examples/cosign/pipeline-ko.yaml
@@ -72,3 +72,5 @@ spec:
           value: "$(tasks.build-with-ko.results.IMAGE_URL)"
         - name: image-digest
           value: "$(tasks.build-with-ko.results.IMAGE_DIGEST)"
+        - name: fail-on
+          value: high

--- a/examples/examples.cue
+++ b/examples/examples.cue
@@ -67,6 +67,10 @@ ssf: task: "grype-vulnerability-scan": {
 			name: "fail-on"
 			description: "set the return code to 1 if a vulnerability is found with a severity >= the given severity, options=[negligible low medium high critical]"
 			default: "medium"
+		}, {
+			name: "only-fixed"
+			description: "ignore matches for vulnerabilities that are not fixed (blank to disable)"
+			default: "--only-fixed"
 		}]
 		stepTemplate: {
 			name: "PIPELINE_DEBUG"
@@ -79,7 +83,8 @@ ssf: task: "grype-vulnerability-scan": {
 			args: [
 				"$(params.image-ref)@$(params.image-digest)",
 				"-v",
-				"-f",
+				"$(params.only-fixed)",
+				"--fail-on",
 				"$(params.fail-on)",
 			]
 			image: "anchore/grype:v0.34.1@sha256:4808f489d418599be4970108535cd1a0638027719b55df653646be0c9613a954"

--- a/examples/sample-pipeline/sample-pipeline.cue
+++ b/examples/sample-pipeline/sample-pipeline.cue
@@ -189,43 +189,6 @@ ssf: task: "deploy-using-kubectl": {
 	}
 }
 
-ssf: task: "grype-vulnerability-scan": {
-	spec: {
-		params: [{
-			description: "image reference"
-			name:        "image-ref"
-		}, {
-			description: "image digest"
-			name:        "image-digest"
-		}, {
-			default:     "0"
-			description: "toggles debug mode for the pipeline"
-			name:        "pipeline-debug"
-		}, {
-			name: "fail-on"
-			description: "set the return code to 1 if a vulnerability is found with a severity >= the given severity, options=[negligible low medium high critical]"
-			default: "medium"
-		}]
-		stepTemplate: {
-			name: "PIPELINE_DEBUG"
-			env: [{
-				name:  "PIPELINE_DEBUG"
-				value: "$(params.pipeline-debug)"
-			}]
-		}
-		steps: [{
-			args: [
-				"$(params.image-ref)@$(params.image-digest)",
-				"-v",
-				"-f",
-				"$(params.fail-on)",
-			]
-			image: "anchore/grype:v0.34.1@sha256:4808f489d418599be4970108535cd1a0638027719b55df653646be0c9613a954"
-			name:  "grype-scanner"
-		}]
-	}
-}
-
 ssf: task: "syft-bom-generator": {
 	spec: {
 		params: [{


### PR DESCRIPTION
Adjust the grype task to allow for ignoring of vulnerabilities that currently have no fix.

Signed-off-by: Brad Beck <bradley.beck@gmail.com>
